### PR TITLE
Updated README to show how to parse a licence string

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,54 @@ There is an execution result:
 ```
 
 NOTICE: All numeric data will be converted to strings after parsing. You need to take care of a parsed data types.
+
+## Parse and verify license string
+
+```javascript
+const licenseFile = require('nodejs-license-file');
+
+try {
+
+    const licence = `
+====BEGIN LICENSE====
+1
+1.0.0
+Name
+Last Name
+some@email.com
+12/10/2025
+xxxxxxxxxxxxxxxxxxxxx
+=====END LICENSE=====
+    `;
+ 
+    const data = licenseFile.parse({
+        publicKeyPath: 'path/to/key.pub',
+        licenseFile: licence,
+        template
+    });
+    
+    console.log(data);
+    
+} catch (err) {
+    
+    console.log(err);
+}
+```
+
+There is an execution result:
+```
+{
+    valid: true,
+    serial: 'oZDqoEr2avwhAqwV4HInq9otNzeBeD/azq2yn2jA ...',
+    data: {
+        licenseVersion: '1',
+        applicationVersion: '1.0.0',
+        firstName: 'Name',
+        lastName: 'Last Name',
+        email: 'some@email.com',
+        expirationDate: '12/10/2025'
+    }
+}
+```
+
+NOTICE: All numeric data will be converted to strings after parsing. You need to take care of a parsed data types.


### PR DESCRIPTION
I needed to parse a licence string and it wasn't on the README but noticed it was possible in the code so thought I'd add it to the README for future users to find.